### PR TITLE
Fix useDialogs hook to call onClose callback on modal close

### DIFF
--- a/packages/app-admin/src/components/Dialogs/DialogsContext.tsx
+++ b/packages/app-admin/src/components/Dialogs/DialogsContext.tsx
@@ -75,6 +75,18 @@ export const DialogsProvider = ({ children }: DialogsProviderProps) => {
     };
 
     const closeDialog = (id: string) => {
+        const dialog = dialogs.get(id);
+        
+        // Call the onClose callback if it exists
+        if (dialog?.onClose && typeof dialog.onClose === "function") {
+            try {
+                dialog.onClose();
+            } catch (error) {
+                // Log error but don't prevent dialog cleanup
+                console.error("Error in dialog onClose callback:", error);
+            }
+        }
+        
         setDialogs(dialogs => {
             const newDialogs = new Map(dialogs);
             newDialogs.delete(id);


### PR DESCRIPTION
View Palmier run: https://app.palmier.io/runs/job_9e54ec19-8b84-4462-919b-8daab9798a71

---

🔧 This PR fixes a critical bug in the useDialogs hook where the onClose callback was not being invoked when dialogs were closed, ensuring proper cleanup and state management for modal components.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Dialog Cleanup Logic**: Added proper onClose callback invocation in the `closeDialog` function before removing the dialog from state
- **Error Handling**: Implemented try-catch block to handle potential errors in onClose callbacks without preventing dialog cleanup
- **State Management**: Enhanced the dialog closing flow to respect component lifecycle callbacks

### Technical Implementation
```mermaid
sequenceDiagram
    participant Component as Dialog Component
    participant Hook as useDialogs Hook
    participant Context as DialogsContext
    participant State as Dialog State

    Component->>Hook: closeDialog(id)
    Hook->>Context: closeDialog(id)
    Context->>State: dialogs.get(id)
    State-->>Context: dialog object
    
    alt dialog.onClose exists
        Context->>Component: dialog.onClose()
        Note over Context,Component: Error handling with try-catch
    end
    
    Context->>State: setDialogs (remove dialog)
    State-->>Hook: Updated state
    Hook-->>Component: Dialog closed
```

### Impact
- **Proper Lifecycle Management**: Components can now perform cleanup operations when dialogs are closed programmatically
- **Enhanced Reliability**: Error handling ensures that callback failures don't prevent dialog removal from state
- **Backward Compatibility**: Change is non-breaking as it only adds functionality for dialogs that define onClose callbacks

</details>

_Created with [Palmier](https://www.palmier.io)_